### PR TITLE
FIX: return type for max_load_factor should be float instead of void.

### DIFF
--- a/src/RobinHoodInfobytePair.h
+++ b/src/RobinHoodInfobytePair.h
@@ -351,7 +351,7 @@ public:
         return 0 == _num_elements;
     }
 
-    inline void max_load_factor() const {
+    inline float max_load_factor() const {
         return _max_load_factor;
     }
 

--- a/src/RobinHoodInfobytePairNoOverflow.h
+++ b/src/RobinHoodInfobytePairNoOverflow.h
@@ -346,7 +346,7 @@ public:
         return 0 == _num_elements;
     }
 
-    inline void max_load_factor() const {
+    inline float max_load_factor() const {
         return _max_load_factor;
     }
 


### PR DESCRIPTION
GCC 6 reports these as compiler errors with -fpermissive.