### PR TITLE
Fix calcNumBytesInfo

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -1767,7 +1767,7 @@ public:
     }
 
     ROBIN_HOOD(NODISCARD) size_t calcNumBytesInfo(size_t numElements) const {
-        return numElements + sizeof(uint64_t);
+        return numElements * sizeof(uint64_t);
     }
 
     // calculation ony allowed for 2^n values


### PR DESCRIPTION
While testing I found that memory reported by `calcNumBytesTotal()` seemed suspiciously low. This seems like an obvious bug but maybe I'm missing something.