### PR TITLE
Support unordered_set

### DIFF
--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -8,7 +8,8 @@ target_sources_local(rh PRIVATE
     bench_hash_int.cpp
     bench_hash_string.cpp
     bench_iterate.cpp
-    bench_quick_overall.cpp
+    bench_quick_overall_map.cpp
+    bench_quick_overall_set.cpp
     bench_random_insert_erase.cpp
 
     # count
@@ -68,5 +69,6 @@ target_sources_local(rh PRIVATE
     unit_sizeof.cpp
     unit_undefined_behavior_nekrolm.cpp
     unit_unique_ptr.cpp
+    unit_unordered_set.cpp
     unit_vectorofmaps.cpp
 )

--- a/src/test/unit/bench_quick_overall_map.cpp
+++ b/src/test/unit/bench_quick_overall_map.cpp
@@ -61,8 +61,8 @@ void benchRandomInsertErase(ankerl::nanobench::Config* cfg) {
                 verifier += map.erase(key);
             }
         }
-        REQUIRE(verifier == 1996311U);
-        REQUIRE(map.size() == 9966U);
+        CHECK(verifier == 1996311U);
+        CHECK(map.size() == 9966U);
     });
 }
 
@@ -95,7 +95,7 @@ void benchIterate(ankerl::nanobench::Config* cfg) {
             }
         } while (!map.empty());
 
-        REQUIRE(result == 62343599601U);
+        CHECK(result == 62343599601U);
     });
 }
 
@@ -135,9 +135,9 @@ void benchRandomFind(ankerl::nanobench::Config* cfg) {
             }
         }
 
-        REQUIRE(checksum == 12570603553U);
-        REQUIRE(found == 4972187U);
-        REQUIRE(notFound == 5027813U);
+        CHECK(checksum == 12570603553U);
+        CHECK(found == 4972187U);
+        CHECK(notFound == 5027813U);
     });
 }
 
@@ -158,7 +158,7 @@ double geomean1(ankerl::nanobench::Config const& cfg) {
 
 // A relatively quick benchmark that should get a relatively good single number of how good the map
 // is. It calculates geometric mean of several benchmarks.
-TEST_CASE("bench_quick_overall_flat" * doctest::test_suite("bench") * doctest::skip()) {
+TEST_CASE("bench_quick_overall_map_flat" * doctest::test_suite("bench") * doctest::skip()) {
     ankerl::nanobench::Config cfg;
     benchAll<robin_hood::unordered_flat_map<uint64_t, size_t>>(&cfg);
     benchAll<robin_hood::unordered_flat_map<std::string, size_t>>(&cfg);
@@ -169,7 +169,7 @@ TEST_CASE("bench_quick_overall_flat" * doctest::test_suite("bench") * doctest::s
 #endif
 }
 
-TEST_CASE("bench_quick_overall_node" * doctest::test_suite("bench") * doctest::skip()) {
+TEST_CASE("bench_quick_overall_map_node" * doctest::test_suite("bench") * doctest::skip()) {
     ankerl::nanobench::Config cfg;
     benchAll<robin_hood::unordered_node_map<uint64_t, size_t>>(&cfg);
     benchAll<robin_hood::unordered_node_map<std::string, size_t>>(&cfg);
@@ -180,9 +180,23 @@ TEST_CASE("bench_quick_overall_node" * doctest::test_suite("bench") * doctest::s
 #endif
 }
 
-TEST_CASE("bench_quick_overall_std" * doctest::test_suite("bench") * doctest::skip()) {
+TEST_CASE("bench_quick_overall_map_std" * doctest::test_suite("bench") * doctest::skip()) {
     ankerl::nanobench::Config cfg;
     benchAll<std::unordered_map<uint64_t, size_t>>(&cfg);
     benchAll<std::unordered_map<std::string, size_t>>(&cfg);
     std::cout << geomean1(cfg) << std::endl;
+}
+
+// 3345972 kb unordered_flat_map
+// 2616020 kb unordered_node_map
+// 4071892 kb std::unordered_map
+TEST_CASE_TEMPLATE("memory_map_huge" * doctest::test_suite("bench") * doctest::skip(), Map,
+                   robin_hood::unordered_flat_map<uint64_t, size_t>,
+                   robin_hood::unordered_node_map<uint64_t, size_t>,
+                   std::unordered_map<uint64_t, size_t>) {
+    Map map;
+    for (uint64_t n = 0; n < 80000000; ++n) {
+        map[n];
+    }
+    std::cout << map.size() << std::endl;
 }

--- a/src/test/unit/bench_quick_overall_set.cpp
+++ b/src/test/unit/bench_quick_overall_set.cpp
@@ -1,0 +1,208 @@
+//#define ROBIN_HOOD_COUNT_ENABLED
+
+#include <robin_hood.h>
+
+#include <app/benchmark.h>
+#include <app/doctest.h>
+#include <app/geomean.h>
+#include <app/sfc64.h>
+#include <thirdparty/nanobench/nanobench.h>
+
+#include <unordered_set>
+
+TYPE_TO_STRING(robin_hood::unordered_flat_set<uint64_t>);
+TYPE_TO_STRING(robin_hood::unordered_flat_set<std::string>);
+TYPE_TO_STRING(robin_hood::unordered_node_set<uint64_t>);
+TYPE_TO_STRING(robin_hood::unordered_node_set<std::string>);
+TYPE_TO_STRING(std::unordered_set<uint64_t>);
+TYPE_TO_STRING(std::unordered_set<std::string>);
+
+namespace {
+
+template <typename K>
+inline K initKey();
+
+template <>
+inline uint64_t initKey<uint64_t>() {
+    return {};
+}
+inline void randomizeKey(sfc64* rng, int n, uint64_t* key) {
+    // we limit ourselfes to 32bit n
+    auto limited = (((*rng)() >> 32U) * static_cast<uint64_t>(n)) >> 32U;
+    *key = limited;
+}
+inline size_t getSizeT(uint64_t val) {
+    return static_cast<size_t>(val);
+}
+inline size_t getSizeT(std::string const& str) {
+    uint64_t x;
+    std::memcpy(&x, str.data(), sizeof(uint64_t));
+    return static_cast<size_t>(x);
+}
+
+template <>
+inline std::string initKey<std::string>() {
+    std::string str;
+    str.resize(200);
+    return str;
+}
+inline void randomizeKey(sfc64* rng, int n, std::string* key) {
+    uint64_t k;
+    randomizeKey(rng, n, &k);
+    std::memcpy(&(*key)[0], &k, sizeof(k));
+}
+
+// Random insert & erase
+template <typename Set>
+void benchRandomInsertErase(ankerl::nanobench::Config* cfg) {
+    cfg->run(type_string(Set{}) + " random insert erase", [&] {
+        sfc64 rng(123);
+        size_t verifier{};
+        Set set;
+        auto key = initKey<typename Set::key_type>();
+        for (int n = 1; n < 20000; ++n) {
+            for (int i = 0; i < 200; ++i) {
+                randomizeKey(&rng, n, &key);
+                set.insert(key);
+                randomizeKey(&rng, n, &key);
+                verifier += set.erase(key);
+            }
+        }
+        CHECK(verifier == 1996311U);
+        CHECK(set.size() == 9966U);
+    });
+}
+
+// iterate
+template <typename Set>
+void benchIterate(ankerl::nanobench::Config* cfg) {
+    size_t numElements = 5000;
+
+    auto key = initKey<typename Set::key_type>();
+
+    // insert
+    cfg->run(type_string(Set{}) + " iterate while adding then removing", [&] {
+        sfc64 rng(555);
+        Set set;
+        size_t result = 0;
+        for (size_t n = 0; n < numElements; ++n) {
+            randomizeKey(&rng, 1000000, &key);
+            set.insert(key);
+            for (auto const& keyVal : set) {
+                result += getSizeT(keyVal);
+            }
+        }
+
+        rng.seed(555);
+        do {
+            randomizeKey(&rng, 1000000, &key);
+            set.erase(key);
+            for (auto const& keyVal : set) {
+                result += getSizeT(keyVal);
+            }
+        } while (!set.empty());
+
+        CHECK(result == 12620652940000U);
+    });
+}
+
+template <typename Set>
+void benchRandomFind(ankerl::nanobench::Config* cfg) {
+    cfg->run(type_string(Set{}) + " 50% probability to find", [&] {
+        sfc64 numberesInsertRng(222);
+        sfc64 numbersSearchRng(222);
+
+        sfc64 insertionRng(123);
+
+        size_t checksum = 0;
+        size_t found = 0;
+        size_t notFound = 0;
+
+        Set set;
+        auto key = initKey<typename Set::key_type>();
+        for (size_t i = 0; i < 10000; ++i) {
+            randomizeKey(&numberesInsertRng, 1000000, &key);
+            if (insertionRng.uniform(100) < 50) {
+                set.insert(key);
+            }
+
+            // search 1000 entries in the set
+            for (size_t search = 0; search < 1000; ++search) {
+                randomizeKey(&numbersSearchRng, 1000000, &key);
+                auto it = set.find(key);
+                if (it != set.end()) {
+                    checksum += getSizeT(*it);
+                    ++found;
+                } else {
+                    ++notFound;
+                }
+                if (numbersSearchRng.counter() == numberesInsertRng.counter()) {
+                    numbersSearchRng.seed(222);
+                }
+            }
+        }
+
+        CHECK(checksum == 2551566706382U);
+        CHECK(found == 4972187U);
+        CHECK(notFound == 5027813U);
+    });
+}
+
+template <typename Set>
+void benchAll(ankerl::nanobench::Config* cfg) {
+    cfg->title("benchmarking");
+    benchIterate<Set>(cfg);
+    benchRandomInsertErase<Set>(cfg);
+    benchRandomFind<Set>(cfg);
+}
+
+double geomean1(ankerl::nanobench::Config const& cfg) {
+    return geomean(cfg.results(),
+                   [](ankerl::nanobench::Result const& result) { return result.median().count(); });
+}
+
+} // namespace
+
+// A relatively quick benchmark that should get a relatively good single number of how good the set
+// is. It calculates geometric mean of several benchmarks.
+TEST_CASE("bench_quick_overall_set_flat" * doctest::test_suite("bench") * doctest::skip()) {
+    ankerl::nanobench::Config cfg;
+    benchAll<robin_hood::unordered_flat_set<uint64_t>>(&cfg);
+    benchAll<robin_hood::unordered_flat_set<std::string>>(&cfg);
+    std::cout << geomean1(cfg) << std::endl;
+
+#ifdef ROBIN_HOOD_COUNT_ENABLED
+    std::cout << robin_hood::counts() << std::endl;
+#endif
+}
+
+TEST_CASE("bench_quick_overall_set_node" * doctest::test_suite("bench") * doctest::skip()) {
+    ankerl::nanobench::Config cfg;
+    benchAll<robin_hood::unordered_node_set<uint64_t>>(&cfg);
+    benchAll<robin_hood::unordered_node_set<std::string>>(&cfg);
+    std::cout << geomean1(cfg) << std::endl;
+
+#ifdef ROBIN_HOOD_COUNT_ENABLED
+    std::cout << robin_hood::counts() << std::endl;
+#endif
+}
+
+TEST_CASE("bench_quick_overall_set_std" * doctest::test_suite("bench") * doctest::skip()) {
+    ankerl::nanobench::Config cfg;
+    benchAll<std::unordered_set<uint64_t>>(&cfg);
+    benchAll<std::unordered_set<std::string>>(&cfg);
+    std::cout << geomean1(cfg) << std::endl;
+}
+
+// 1773116 kb unordered_flat_set
+// 2362932 kb unordered_node_set
+// 4071776 kb std::unordered_set
+TEST_CASE_TEMPLATE("memory_set_huge" * doctest::test_suite("bench") * doctest::skip(), Set,
+                   robin_hood::unordered_flat_set<uint64_t>,
+                   robin_hood::unordered_node_set<uint64_t>, std::unordered_set<uint64_t>) {
+    Set set;
+    for (uint64_t n = 0; n < 80000000; ++n) {
+        set.insert(n);
+    }
+    std::cout << set.size() << std::endl;
+}

--- a/src/test/unit/unit_unordered_set.cpp
+++ b/src/test/unit/unit_unordered_set.cpp
@@ -1,0 +1,27 @@
+#include <robin_hood.h>
+
+#include <app/doctest.h>
+
+#include <iostream>
+
+TYPE_TO_STRING(robin_hood::unordered_flat_set<uint64_t>);
+TYPE_TO_STRING(robin_hood::unordered_node_set<uint64_t>);
+
+TEST_CASE_TEMPLATE("unordered_set", Set, robin_hood::unordered_flat_set<uint64_t>,
+                   robin_hood::unordered_node_set<uint64_t>) {
+
+    REQUIRE(sizeof(typename Set::value_type) == sizeof(uint64_t));
+
+    Set set;
+    set.emplace(UINT64_C(123));
+    REQUIRE(set.size() == 1U);
+
+    set.insert(UINT64_C(333));
+    REQUIRE(set.size() == 2U);
+
+    set.erase(UINT64_C(222));
+    REQUIRE(set.size() == 2U);
+
+    set.erase(UINT64_C(123));
+    REQUIRE(set.size() == 1U);
+}


### PR DESCRIPTION
Based on the pair-with-void idea from @amosbird in https://github.com/martinus/robin-hood-hashing/pull/55, This PR now fully implements `unordered_flat_set` and `unordered_node_set`, with c++11 support. Yay!

Solves #7 