### PR TITLE
Heterogeneous lookup

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -562,6 +562,8 @@ struct nothrow {
 
 } // namespace detail
 
+struct is_transparent_tag {};
+
 // A custom pair implementation is used in the map because std::pair is not is_trivially_copyable,
 // which means it would  not be allowed to be used in std::memcpy. This struct is copyable, which is
 // also tested.
@@ -1742,6 +1744,13 @@ public:
         return const_iterator{mKeyVals + idx, mInfo + idx};
     }
 
+    template <typename OtherKey>
+    const_iterator find(const OtherKey& key, is_transparent_tag /*unused*/) const {
+        ROBIN_HOOD_TRACE(this);
+        const size_t idx = findIdx(key);
+        return const_iterator{mKeyVals + idx, mInfo + idx};
+    }
+
     template <typename OtherKey, typename Self_ = Self>
     typename std::enable_if<Self_::is_transparent, const_iterator>::type
     find(const OtherKey& key) const {
@@ -1751,6 +1760,13 @@ public:
     }
 
     iterator find(const key_type& key) {
+        ROBIN_HOOD_TRACE(this);
+        const size_t idx = findIdx(key);
+        return iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey>
+    iterator find(const OtherKey& key, is_transparent_tag /*unused*/) {
         ROBIN_HOOD_TRACE(this);
         const size_t idx = findIdx(key);
         return iterator{mKeyVals + idx, mInfo + idx};

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources_local(rh PRIVATE
     unit_count.cpp
     unit_diamond.cpp
     unit_empty.cpp
+    unit_heterogeneous.cpp
     include_only.h
     include_only.cpp
     unit_include_only.cpp

--- a/src/test/unit/unit_heterogeneous.cpp
+++ b/src/test/unit/unit_heterogeneous.cpp
@@ -36,12 +36,12 @@ struct MyEqual {
     }
 };
 
-TYPE_TO_STRING(robin_hood::unordered_flat_map<std::string, int, MyHash, MyEqual>);
-TYPE_TO_STRING(robin_hood::unordered_node_map<std::string, int, MyHash, MyEqual>);
+TYPE_TO_STRING(robin_hood::unordered_flat_map<std::string, uint64_t, MyHash, MyEqual>);
+TYPE_TO_STRING(robin_hood::unordered_node_map<std::string, uint64_t, MyHash, MyEqual>);
 
 TEST_CASE_TEMPLATE("heterogeneous", Map,
-                   robin_hood::unordered_flat_map<std::string, int, MyHash, MyEqual>,
-                   robin_hood::unordered_node_map<std::string, int, MyHash, MyEqual>) {
+                   robin_hood::unordered_flat_map<std::string, uint64_t, MyHash, MyEqual>,
+                   robin_hood::unordered_node_map<std::string, uint64_t, MyHash, MyEqual>) {
     Map map;
     const Map& cmap = map;
     REQUIRE(map.count("123") == 0);

--- a/src/test/unit/unit_heterogeneous.cpp
+++ b/src/test/unit/unit_heterogeneous.cpp
@@ -1,0 +1,66 @@
+#include <robin_hood.h>
+
+#include <app/doctest.h>
+
+#include <cstring>
+
+static bool disable_string_operator = true;
+
+struct MyHash {
+    using is_transparent = void;
+
+    size_t operator()(const std::string& str) const {
+        if (disable_string_operator) {
+            throw std::runtime_error("No hashing of string is allowed");
+        }
+        return robin_hood::hash_bytes(str.c_str(), str.size());
+    }
+
+    size_t operator()(const char* str) const noexcept {
+        return robin_hood::hash_bytes(str, std::strlen(str));
+    }
+};
+
+struct MyEqual {
+    using is_transparent = void;
+
+    bool operator()(const char* lhs, const std::string& rhs) const noexcept {
+        return std::strcmp(lhs, rhs.c_str()) == 0;
+    }
+
+    bool operator()(const std::string& lhs, const std::string& rhs) const {
+        if (disable_string_operator) {
+            throw std::runtime_error("No comparison of string to string is allowed");
+        }
+        return lhs == rhs;
+    }
+};
+
+TYPE_TO_STRING(robin_hood::unordered_flat_map<std::string, int, MyHash, MyEqual>);
+TYPE_TO_STRING(robin_hood::unordered_node_map<std::string, int, MyHash, MyEqual>);
+
+TEST_CASE_TEMPLATE("heterogeneous", Map,
+                   robin_hood::unordered_flat_map<std::string, int, MyHash, MyEqual>,
+                   robin_hood::unordered_node_map<std::string, int, MyHash, MyEqual>) {
+    Map map;
+    const Map& cmap = map;
+    REQUIRE(map.count("123") == 0);
+    REQUIRE(map.count("0") == 0);
+    REQUIRE(!map.contains("123"));
+    REQUIRE(!map.contains("0"));
+    REQUIRE(map.find("123") == map.end());
+    REQUIRE(map.find("0") == map.end());
+    REQUIRE(cmap.find("123") == map.cend());
+    REQUIRE(cmap.find("0") == map.cend());
+    disable_string_operator = false;
+    map["123"];
+    disable_string_operator = true;
+    REQUIRE(map.count("123") == 1);
+    REQUIRE(map.count("0") == 0);
+    REQUIRE(map.contains("123"));
+    REQUIRE(!map.contains("0"));
+    REQUIRE(map.find("123") == map.begin());
+    REQUIRE(map.find("0") == map.end());
+    REQUIRE(cmap.find("123") == map.cbegin());
+    REQUIRE(cmap.find("0") == map.cend());
+}


### PR DESCRIPTION
This PR implements heterogeneous lookup in `robin_hood::unordered_set` and `robin_hood::unordered_map`.

As hinted in #39 this is based on [P1690R0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1690r0.html) which means it is enabled if both the provided `Hash` and `KeyEqual` types have an `is_transparent` tag. 

I've also added heterogeneous "overloads" for `count` and `contains`

A unit test is added to check the newly added code and that no conversion happens thanks to the heterogeneous lookup.