### PR TITLE
Use tzcnt instead of bsf for better performance on ZEN/ZEN2.

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -128,7 +128,23 @@ static Counts& counts() {
 #endif
 
 // count leading/trailing bits
-#ifdef _MSC_VER
+#if ( ( defined __i386 || defined __x86_64__ ) && defined __BMI__ ) || defined _M_IX86 || defined _M_X64
+#    ifdef _MSC_VER
+#        include <intrin.h>
+#    else
+#        include <x86intrin.h>
+#    endif
+#    if ROBIN_HOOD(BITNESS) == 32
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_CTZ() _tzcnt_u32
+#    else
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_CTZ() _tzcnt_u64
+#    endif
+#    if defined __AVX2__ || defined __BMI__
+#        define ROBIN_HOOD_COUNT_TRAILING_ZEROES(x) static_cast<int>(ROBIN_HOOD(CTZ)(x))
+#    else
+#        define ROBIN_HOOD_COUNT_TRAILING_ZEROES(x) ((x) ? static_cast<int>(ROBIN_HOOD(CTZ)(x)) : ROBIN_HOOD(BITNESS))
+#    endif
+#elif defined _MSC_VER
 #    if ROBIN_HOOD(BITNESS) == 32
 #        define ROBIN_HOOD_PRIVATE_DEFINITION_BITSCANFORWARD() _BitScanForward
 #    else


### PR DESCRIPTION
Details in #73.