### PR TITLE
Fix is_transparent typedef detection

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -793,11 +793,17 @@ ROBIN_HOOD_HASH_INT(unsigned long long);
 #endif
 namespace detail {
 
+template <typename T>
+struct void_type {
+    using type = void;
+};
+
 template <typename T, typename = void>
 struct has_is_transparent : public std::false_type {};
 
 template <typename T>
-struct has_is_transparent<T, typename T::is_transparent> : public std::true_type {};
+struct has_is_transparent<T, typename void_type<typename T::is_transparent>::type>
+    : public std::true_type {};
 
 // using wrapper classes for hash and key_equal prevents the diamond problem when the same type
 // is used. see https://stackoverflow.com/a/28771920/48181

--- a/src/test/unit/unit_heterogeneous.cpp
+++ b/src/test/unit/unit_heterogeneous.cpp
@@ -22,7 +22,7 @@ struct MyHash {
 };
 
 struct MyEqual {
-    using is_transparent = void;
+    using is_transparent = int;
 
     bool operator()(const char* lhs, const std::string& rhs) const noexcept {
         return std::strcmp(lhs, rhs.c_str()) == 0;
@@ -42,6 +42,7 @@ TYPE_TO_STRING(robin_hood::unordered_node_map<std::string, uint64_t, MyHash, MyE
 TEST_CASE_TEMPLATE("heterogeneous", Map,
                    robin_hood::unordered_flat_map<std::string, uint64_t, MyHash, MyEqual>,
                    robin_hood::unordered_node_map<std::string, uint64_t, MyHash, MyEqual>) {
+    static_assert(Map::is_transparent, "not transparent");
     Map map;
     const Map& cmap = map;
     REQUIRE(map.count("123") == 0);


### PR DESCRIPTION
This fixes `is_transparent` typedef detection mechanism. Currently, it requires `is_transparent` to be the typedef of `void` which is too strict - VC++ defines its standard transparent operator functors with `is_transparent` being a typedef of `int`.