### PR TITLE
Add member functions from C++17

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -36,7 +36,7 @@
 
 // see https://semver.org/
 #define ROBIN_HOOD_VERSION_MAJOR 3 // for incompatible API changes
-#define ROBIN_HOOD_VERSION_MINOR 7 // for adding functionality in a backwards-compatible manner
+#define ROBIN_HOOD_VERSION_MINOR 8 // for adding functionality in a backwards-compatible manner
 #define ROBIN_HOOD_VERSION_PATCH 0 // for backwards-compatible bug fixes
 
 #include <algorithm>
@@ -1687,6 +1687,28 @@ public:
         return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
     }
 
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(const key_type& key, Mapped&& obj) {
+        return insert_or_assign_impl(key, std::forward<Mapped>(obj));
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(key_type&& key, Mapped&& obj) {
+        return insert_or_assign_impl(std::move(key), std::forward<Mapped>(obj));
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(const_iterator hint, const key_type& key, Mapped&& obj) {
+        (void)hint;
+        return insert_or_assign_impl(key, std::forward<Mapped>(obj));
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(const_iterator hint, key_type&& key, Mapped&& obj) {
+        (void)hint;
+        return insert_or_assign_impl(std::move(key), std::forward<Mapped>(obj));
+    }
+
     std::pair<iterator, bool> insert(const value_type& keyval) {
         ROBIN_HOOD_TRACE(this)
         return doInsert(keyval);
@@ -2026,6 +2048,17 @@ private:
             return emplace(std::piecewise_construct, std::forward_as_tuple(std::forward<OtherKey>(key)),
                            std::forward_as_tuple(std::forward<Args>(args)...));
         }
+        return {it, false};
+    }
+
+    template <typename OtherKey, typename Mapped>
+    std::pair<iterator, bool> insert_or_assign_impl(OtherKey&& key, Mapped&& obj) {
+        ROBIN_HOOD_TRACE(this)
+        auto it = find(key);
+        if (it == end()) {
+            return emplace(std::forward<OtherKey>(key), std::forward<Mapped>(obj));
+        }
+        it->second = std::forward<Mapped>(obj);
         return {it, false};
     }
 

--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -1665,6 +1665,28 @@ public:
         return r;
     }
 
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const key_type& key, Args&&... args) {
+        return try_emplace_impl(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(key_type&& key, Args&&... args) {
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const_iterator hint, const key_type& key, Args&&... args) {
+        (void)hint;
+        return try_emplace_impl(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const_iterator hint, key_type&& key, Args&&... args) {
+        (void)hint;
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
+    }
+
     std::pair<iterator, bool> insert(const value_type& keyval) {
         ROBIN_HOOD_TRACE(this)
         return doInsert(keyval);
@@ -1994,6 +2016,17 @@ private:
 #else
         abort();
 #endif
+    }
+
+    template <typename OtherKey, typename... Args>
+    std::pair<iterator, bool> try_emplace_impl(OtherKey&& key, Args&&... args) {
+        ROBIN_HOOD_TRACE(this)
+        auto it = find(key);
+        if (it == end()) {
+            return emplace(std::piecewise_construct, std::forward_as_tuple(std::forward<OtherKey>(key)),
+                           std::forward_as_tuple(std::forward<Args>(args)...));
+        }
+        return {it, false};
     }
 
     void init_data(size_t max_elements) {

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources_local(rh PRIVATE
     unit_include_only.cpp
     unit_initializerlist.cpp
     unit_insert.cpp
+    unit_insert_or_assign.cpp
     unit_iterator_twice_bug.cpp
     unit_iterators_ctor.cpp
     unit_iterators_empty.cpp

--- a/src/test/unit/CMakeLists.txt
+++ b/src/test/unit/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources_local(rh PRIVATE
     unit_sfc64_is_deterministic.cpp
     unit_sizeof.cpp
     unit_string.cpp
+    unit_try_emplace.cpp
     unit_undefined_behavior_nekrolm.cpp
     unit_unique_ptr.cpp
     unit_unordered_set.cpp

--- a/src/test/unit/unit_insert_or_assign.cpp
+++ b/src/test/unit/unit_insert_or_assign.cpp
@@ -1,0 +1,54 @@
+#include <robin_hood.h>
+
+#include <app/doctest.h>
+
+#include <string>
+
+TYPE_TO_STRING(robin_hood::unordered_flat_map<std::string, std::string>);
+TYPE_TO_STRING(robin_hood::unordered_node_map<std::string, std::string>);
+
+TEST_CASE_TEMPLATE("insert_or_assign", Map,
+                   robin_hood::unordered_flat_map<std::string, std::string>,
+                   robin_hood::unordered_node_map<std::string, std::string>) {
+
+    Map map;
+    auto ret = map.insert_or_assign("a", "b");
+    REQUIRE(ret.second);
+    REQUIRE(ret.first == map.find("a"));
+    REQUIRE(map.size() == 1);
+    REQUIRE(map["a"] == "b");
+
+    ret = map.insert_or_assign("c", "d");
+    REQUIRE(ret.second);
+    REQUIRE(ret.first == map.find("c"));
+    REQUIRE(map.size() == 2);
+    REQUIRE(map["c"] == "d");
+
+    ret = map.insert_or_assign("c", "dd");
+    REQUIRE_FALSE(ret.second);
+    REQUIRE(ret.first == map.find("c"));
+    REQUIRE(map.size() == 2);
+    REQUIRE(map["c"] == "dd");
+
+    std::string key = "a";
+    std::string value = "bb";
+    ret = map.insert_or_assign(key, value);
+    REQUIRE_FALSE(ret.second);
+    REQUIRE(ret.first == map.find("a"));
+    REQUIRE(map.size() == 2);
+    REQUIRE(map["a"] == "bb");
+
+    key = "e";
+    value = "f";
+    ret = map.insert_or_assign(map.end(), key, value);
+    REQUIRE(ret.second);
+    REQUIRE(ret.first == map.find("e"));
+    REQUIRE(map.size() == 3);
+    REQUIRE(map["e"] == "f");
+
+    ret = map.insert_or_assign(map.begin(), "e", "ff");
+    REQUIRE_FALSE(ret.second);
+    REQUIRE(ret.first == map.find("e"));
+    REQUIRE(map.size() == 3);
+    REQUIRE(map["e"] == "ff");
+}

--- a/src/test/unit/unit_try_emplace.cpp
+++ b/src/test/unit/unit_try_emplace.cpp
@@ -1,0 +1,68 @@
+#include <robin_hood.h>
+
+#include <app/doctest.h>
+
+#include <string>
+
+struct RegularType {
+    // cppcheck-suppress passedByValue
+    RegularType(std::size_t i_, std::string s_) noexcept
+        : s(std::move(s_))
+        , i(i_) {}
+
+    friend bool operator==(const RegularType& r1, const RegularType& r2) {
+        return r1.i == r2.i && r1.s == r2.s;
+    }
+
+    std::string s;
+    std::size_t i;
+};
+
+TYPE_TO_STRING(robin_hood::unordered_flat_map<std::string, RegularType>);
+TYPE_TO_STRING(robin_hood::unordered_node_map<std::string, RegularType>);
+
+TEST_CASE_TEMPLATE("try_emplace", Map, robin_hood::unordered_flat_map<std::string, RegularType>,
+                   robin_hood::unordered_node_map<std::string, RegularType>) {
+
+    Map map;
+    auto ret = map.try_emplace("a", 1U, "b");
+    REQUIRE(ret.second);
+    REQUIRE(ret.first == map.find("a"));
+    REQUIRE(ret.first->second == RegularType(1U, "b"));
+    REQUIRE(map.size() == 1);
+
+    ret = map.try_emplace("c", 2U, "d");
+    REQUIRE(ret.second);
+    REQUIRE(ret.first == map.find("c"));
+    REQUIRE(ret.first->second == RegularType(2U, "d"));
+    REQUIRE(map.size() == 2U);
+
+    std::string key = "c";
+    ret = map.try_emplace(key, 3U, "dd");
+    REQUIRE_FALSE(ret.second);
+    REQUIRE(ret.first == map.find("c"));
+    REQUIRE(ret.first->second == RegularType(2U, "d"));
+    REQUIRE(map.size() == 2U);
+
+    key = "a";
+    RegularType value(3U, "dd");
+    ret = map.try_emplace(key, value);
+    REQUIRE_FALSE(ret.second);
+    REQUIRE(ret.first == map.find("a"));
+    REQUIRE(ret.first->second == RegularType(1U, "b"));
+    REQUIRE(map.size() == 2U);
+
+    ret = map.try_emplace(map.end(), "e", 67U, "f");
+    REQUIRE(ret.second);
+    REQUIRE(ret.first == map.find("e"));
+    REQUIRE(ret.first->second == RegularType(67U, "f"));
+    REQUIRE(map.size() == 3U);
+
+    key = "e";
+    RegularType value2(66U, "ff");
+    ret = map.try_emplace(map.begin(), key, value2);
+    REQUIRE_FALSE(ret.second);
+    REQUIRE(ret.first == map.find("e"));
+    REQUIRE(ret.first->second == RegularType(67U, "f"));
+    REQUIRE(map.size() == 3U);
+}


### PR DESCRIPTION
Adds `try_emplace` and `insert_or_assign` from C++17. Fixes #71.