### PR TITLE
Fix CRC32 support on Windows ARM64 and use runtime detection

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -225,32 +225,26 @@ static Counts& counts() {
 #    define ROBIN_HOOD_PRIVATE_DEFINITION_NODISCARD()
 #endif
 
-// detect hardware CRC availability. Microsoft's _M_IX86_FP only detects if SSE is present, but not
-// if 4.2 is there unfortunately.
+// Use the correct CRC intrinsics. Hardware support is done at runtime.
 #if !defined(ROBIN_HOOD_DISABLE_INTRINSICS)
-#    if defined(__SSE4_2__) || defined(__ARM_FEATURE_CRC32) || \
-        ((defined(_M_IX86_FP) && (_M_IX86_FP >= 2))) || defined(_M_ARM64)
-#        define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_CRC32() 1
-#        if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(_M_ARM64)
-#            ifdef _M_ARM64
-#                include <arm64_neon.h>
-#            else
-#                include <arm_acle.h>
-#            endif
-
-#            define ROBIN_HOOD_CRC32_64(crc, v) \
-                __crc32cd(static_cast<uint32_t>(crc), static_cast<uint64_t>(v))
-#            define ROBIN_HOOD_CRC32_32(crc, v) \
-                __crc32cw(static_cast<uint32_t>(crc), static_cast<uint32_t>(v))
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_CRC32() 1
+#    if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(_M_ARM64)
+#        ifdef _M_ARM64
+#            include <arm64_neon.h>
 #        else
-#            include <nmmintrin.h>
-#            define ROBIN_HOOD_CRC32_64(crc, v) \
-                _mm_crc32_u64(static_cast<uint64_t>(crc), static_cast<uint64_t>(v))
-#            define ROBIN_HOOD_CRC32_32(crc, v) \
-                _mm_crc32_u32(static_cast<uint32_t>(crc), static_cast<uint32_t>(v))
+#            include <arm_acle.h>
 #        endif
+
+#        define ROBIN_HOOD_CRC32_64(crc, v) \
+            __crc32cd(static_cast<uint32_t>(crc), static_cast<uint64_t>(v))
+#        define ROBIN_HOOD_CRC32_32(crc, v) \
+            __crc32cw(static_cast<uint32_t>(crc), static_cast<uint32_t>(v))
 #    else
-#        define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_CRC32() 0
+#        include <nmmintrin.h>
+#        define ROBIN_HOOD_CRC32_64(crc, v) \
+            _mm_crc32_u64(static_cast<uint64_t>(crc), static_cast<uint64_t>(v))
+#        define ROBIN_HOOD_CRC32_32(crc, v) \
+            _mm_crc32_u32(static_cast<uint32_t>(crc), static_cast<uint32_t>(v))
 #    endif
 
 #    if defined(_MSC_VER)

--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -770,17 +770,18 @@ static size_t fallback_hash_bytes(void const* ptr, size_t const len) noexcept {
 
 #if ROBIN_HOOD(HAS_CRC32)
 
+#    ifndef _M_ARM64
 // see e.g.
 // https://github.com/simdjson/simdjson/blob/9863f62321f59d73c7731d4ada2d7c4ed6a0a251/src/isadetection.h
 static inline void cpuid(uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* edx) {
-#    if defined(_MSC_VER)
+#        if defined(_MSC_VER)
     int cpuInfo[4];
     __cpuid(cpuInfo, static_cast<int>(*eax));
     *eax = static_cast<uint32_t>(cpuInfo[0]);
     *ebx = static_cast<uint32_t>(cpuInfo[1]);
     *ecx = static_cast<uint32_t>(cpuInfo[2]);
     *edx = static_cast<uint32_t>(cpuInfo[3]);
-#    else
+#        else
     uint32_t a = *eax;
     uint32_t b{};
     uint32_t c = *ecx;
@@ -791,8 +792,9 @@ static inline void cpuid(uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* 
     *ebx = b;
     *ecx = c;
     *edx = d;
-#    endif
+#        endif
 }
+#    endif
 
 inline bool checkCrc32Support() noexcept {
 #    if defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
@@ -812,6 +814,8 @@ inline bool checkCrc32Support() noexcept {
     if (hwcap != ENOENT) {
         return (hwcap & HWCAP_CRC32) != 0;
     }
+#    elif defined(_M_ARM64)
+    return true;
 #    endif
     return false;
 }


### PR DESCRIPTION
`__cpuid` isn't present on ARM64 builds in Windows, and CRC32 is always present for ARM64 processors that Windows 10 supports (making runtime detection unnecessary).

Also, remove the hardware support detection at compile time. You've already added runtime detection (the more flexible method), so use that.