### PR TITLE
Remove non-ASCII character

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -2329,7 +2329,7 @@ private:
 
         // This protection against not deleting mMask shouldn't be needed as it's sufficiently
         // protected with the 0==mMask check, but I have this anyways because g++ 7 otherwise
-        // reports a compile error: attempt to free a non-heap object ‘fm’
+        // reports a compile error: attempt to free a non-heap object 'fm'
         // [-Werror=free-nonheap-object]
         if (mKeyVals != reinterpret_cast_no_cast_align_warning<Node*>(&mMask)) {
             std::free(mKeyVals);


### PR DESCRIPTION
Fixes msvc warning `C4819: The file contains a character that cannot be represented in the current code page`.