### PR TITLE
Fix memory leak

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -2099,8 +2099,12 @@ private:
             // g++'s overeager "attempt to free a non-heap object 'map'
             // [-Werror=free-nonheap-object]" warning.
             if (oldKeyVals != reinterpret_cast_no_cast_align_warning<Node*>(&mMask)) {
-                // don't destroy old data: put it into the pool instead
-                DataPool::addOrFree(oldKeyVals, calcNumBytesTotal(oldMaxElementsWithBuffer));
+                if(empty()) {
+                    std::free(oldKeyVals);
+                } else {
+                    // don't destroy old data: put it into the pool instead
+                    DataPool::addOrFree(oldKeyVals, calcNumBytesTotal(oldMaxElementsWithBuffer));
+                }
             }
         }
     }


### PR DESCRIPTION
Hello, I've recently integrated your map into my application and it has been working pretty great overall.

However I have a memory leak that I've narrowed down to the robin_hood map. It happens when I continually do the following:
 1. Insert some elements into a map
 2. `clear()`
 3. `reserve(maximumNumberOfElementsEver)`
 4. Repeat steps 1-3

This keeps adding new memory blocks to the memory pool and the memory use keeps growing. I realize the `reserve()` is not necessary but this was a remnant from when I used `std::unordered_map()` and others doing the switch might experience similar issues.