### PR TITLE
Single lookup for try_emplace and insert_or_assign

### DIFF
--- a/src/test/unit/unit_overflow_collisions.cpp
+++ b/src/test/unit/unit_overflow_collisions.cpp
@@ -33,6 +33,7 @@ TEST_CASE_TEMPLATE(
     }
     REQUIRE(CtorDtorVerifier::mapSize() == 0);
 
+    // produce overflow with insert
     {
         Map m;
         for (uint64_t i = 0; i < max_val; ++i) {
@@ -40,6 +41,21 @@ TEST_CASE_TEMPLATE(
         }
         REQUIRE(m.size() == max_val);
         REQUIRE_THROWS_AS(m.insert(typename Map::value_type(max_val, max_val)),
+                          std::overflow_error);
+        REQUIRE(m.size() == max_val);
+    }
+    if (0 != CtorDtorVerifier::mapSize()) {
+        CtorDtorVerifier::printMap();
+    }
+
+    // produce overflow with emplace
+    {
+        Map m;
+        for (uint64_t i = 0; i < max_val; ++i) {
+            REQUIRE(m.insert(typename Map::value_type(i, i)).second);
+        }
+        REQUIRE(m.size() == max_val);
+        REQUIRE_THROWS_AS(m.emplace(typename Map::value_type(max_val, max_val)),
                           std::overflow_error);
         REQUIRE(m.size() == max_val);
     }


### PR DESCRIPTION
Found by @GilesBathgate who provided a POC in #114. Thanks!

Now try_emplace and isnert_or_assign don't require two lookups.

This implementation reuses the same insertion code for insert() and emplace().
Also fixes a bug for emplace() where a node was not destroyed when overflow
exception occured.