### PR TITLE
Fix compiling with MSVC 2015

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -128,7 +128,10 @@ function(add_compile_flags_target target)
     if(MSVC)
         target_compile_options(${target} PRIVATE /EHsc) # exception handling
         target_compile_options(${target} PRIVATE /std:c++latest) # for post c++14 updates in MSVC
-        target_compile_options(${target} PRIVATE /permissive-)   # force standard conformance - this is the better flag than /Za
+        if (CXX_COMPILER_VERSION VERSION_GREATER 19.0)
+            # MSVC 2017 or later
+            target_compile_options(${target} PRIVATE "/permissive-") # force standards conformance - this is the better flag than /Za
+        endif()
         target_compile_options(${target} PRIVATE /WX)
         target_compile_options(${target} PRIVATE /Wall) # turns on warnings from levels 1 through 4 which are off by default - https://msdn.microsoft.com/en-us/library/23k5d385.aspx
         
@@ -152,7 +155,15 @@ function(add_compile_flags_target target)
             /wd4774 # 'swprintf_s' : format string expected in argument 3 is not a string literal
 
             /wd5045 # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+
         )
+        if (CXX_COMPILER_VERSION VERSION_LESS_EQUAL 19.0)
+            # MSVC 2015 produces several warnings that look to be incorrect.
+            target_compile_options(${target} PRIVATE
+                /wd4548 # expression before comma has no effect
+                /wd4996 # 'std::copy' with parameters that may be unsafe
+            )
+        endif()
     endif()
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )

--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -192,6 +192,17 @@ static Counts& counts() {
 #    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART() 1
 #endif
 
+// detect if MSVC supports the pair(std::piecewise_construct_t,...) consructor being constexpr
+#ifdef _MSC_VER
+#    if _MSC_VER <= 1900
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 1
+#     else
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 0
+#    endif
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 0
+#endif
+
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 // See https://stackoverflow.com/a/31798726/48181
 #if defined(__GNUC__) && __GNUC__ < 5
@@ -610,7 +621,12 @@ struct pair {
         , second(std::forward<U2>(b)) {}
 
     template <typename... U1, typename... U2>
-    constexpr pair(
+    // MSVC 2015 produces error "C2476: ‘constexpr’ constructor does not initialize all members"
+    // if this constructor is constexpr
+#if !ROBIN_HOOD(BROKEN_CONSTEXPR)
+    constexpr
+#endif
+    pair(
         std::piecewise_construct_t /*unused*/, std::tuple<U1...> a,
         std::tuple<U2...> b) noexcept(noexcept(pair(std::declval<std::tuple<U1...>&>(),
                                                     std::declval<std::tuple<U2...>&>(),
@@ -1339,7 +1355,7 @@ private:
         // an additional mixing step. This serves as a bad hash prevention, if the given data is
         // badly mixed.
         using Mix =
-            typename std::conditional<std::is_same<::robin_hood::hash<key_type>, hasher>::value,
+            typename std::conditional<std::is_same< ::robin_hood::hash<key_type>, hasher>::value,
                                       ::robin_hood::detail::identity_hash<size_t>,
                                       ::robin_hood::hash<size_t>>::type;
 

--- a/src/test/thirdparty/nanobench/nanobench.h
+++ b/src/test/thirdparty/nanobench/nanobench.h
@@ -2233,8 +2233,8 @@ struct IterationLogic::Impl {
             hash = hash_combine(std::hash<std::string>{}(mBench.title()), hash);
             hash = hash_combine(std::hash<std::string>{}(mBench.timeUnitName()), hash);
             hash = hash_combine(std::hash<double>{}(mBench.timeUnit().count()), hash);
-            hash = hash_combine(mBench.relative(), hash);
-            hash = hash_combine(mBench.performanceCounters(), hash);
+            hash = hash_combine(std::hash<bool>{}(mBench.relative()), hash);
+            hash = hash_combine(std::hash<bool>{}(mBench.performanceCounters()), hash);
 
             if (hash != singletonHeaderHash()) {
                 singletonHeaderHash() = hash;

--- a/src/test/unit/count_one_emplace.cpp
+++ b/src/test/unit/count_one_emplace.cpp
@@ -5,6 +5,7 @@
 #include <app/counter_defaults.h>
 #include <app/sfc64.h>
 
+#if !ROBIN_HOOD(BROKEN_CONSTEXPR)
 TEST_CASE_TEMPLATE("count one emplace" * doctest::test_suite("count") * doctest::skip(), Map,
                    robin_hood::unordered_flat_map<cnt, cnt, std::hash<cnt>>,
                    robin_hood::unordered_flat_map<cnt, cnt, robin_hood::hash<cnt>>,
@@ -19,3 +20,4 @@ TEST_CASE_TEMPLATE("count one emplace" * doctest::test_suite("count") * doctest:
                 std::forward_as_tuple(x, counts));
     counts.printCounts(std::string("one emplace ") + doctest::detail::type_to_string<Map>());
 }
+#endif

--- a/src/test/unit/unit_compact.cpp
+++ b/src/test/unit/unit_compact.cpp
@@ -1,10 +1,10 @@
 #include <robin_hood.h>
 
 #include <app/doctest.h>
-
 TYPE_TO_STRING(robin_hood::unordered_flat_map<uint64_t, uint64_t>);
 TYPE_TO_STRING(robin_hood::unordered_node_map<uint64_t, uint64_t>);
 
+#if !ROBIN_HOOD(BROKEN_CONSTEXPR)
 TEST_CASE_TEMPLATE("compact", Map, robin_hood::unordered_flat_map<uint64_t, uint64_t>,
                    robin_hood::unordered_node_map<uint64_t, uint64_t>) {
     Map map;
@@ -38,3 +38,4 @@ TEST_CASE_TEMPLATE("compact", Map, robin_hood::unordered_flat_map<uint64_t, uint
     map.compact();
     REQUIRE(63 == map.mask());
 }
+#endif

--- a/src/test/unit/unit_try_emplace.cpp
+++ b/src/test/unit/unit_try_emplace.cpp
@@ -4,6 +4,7 @@
 
 #include <string>
 
+#if !ROBIN_HOOD(BROKEN_CONSTEXPR)
 struct RegularType {
     // cppcheck-suppress passedByValue
     RegularType(std::size_t i_, std::string s_) noexcept
@@ -67,3 +68,4 @@ TEST_CASE_TEMPLATE("try_emplace", Map, robin_hood::unordered_flat_map<std::strin
     REQUIRE(ret.first->second == RegularType(67U, "f"));
     REQUIRE(map.size() == 3U);
 }
+#endif


### PR DESCRIPTION
The pair(piecewise_construct_t, ...) constructor causes the error
"C2476: ‘constexpr’ constructor does not initialize all members"

The best information about this error is:
https://devblogs.microsoft.com/cppblog/c11-constant-expressions-in-visual-studio-2015-rc/
but the error happens even with 2015 Update 3.

The test cases that use piecewise_construct_t, try_emplace() or compact() cause internal
compiler errors.