### PR TITLE
The return type of functions that use hints should be consistent with std

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -1821,7 +1821,8 @@ public:
     }
 
     template <typename... Args>
-    iterator emplace_hint(Args&&... args) {
+    iterator emplace_hint(const_iterator position, Args&&... args) {
+        (void)position;
         return emplace(std::forward<Args>(args)...).first;
     }
 
@@ -1836,16 +1837,16 @@ public:
     }
 
     template <typename... Args>
-    std::pair<iterator, bool> try_emplace(const_iterator hint, const key_type& key,
+    iterator try_emplace(const_iterator hint, const key_type& key,
                                           Args&&... args) {
         (void)hint;
-        return try_emplace_impl(key, std::forward<Args>(args)...);
+        return try_emplace_impl(key, std::forward<Args>(args)...).first;
     }
 
     template <typename... Args>
-    std::pair<iterator, bool> try_emplace(const_iterator hint, key_type&& key, Args&&... args) {
+    iterator try_emplace(const_iterator hint, key_type&& key, Args&&... args) {
         (void)hint;
-        return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...).first;
     }
 
     template <typename Mapped>
@@ -1859,16 +1860,16 @@ public:
     }
 
     template <typename Mapped>
-    std::pair<iterator, bool> insert_or_assign(const_iterator hint, const key_type& key,
+    iterator insert_or_assign(const_iterator hint, const key_type& key,
                                                Mapped&& obj) {
         (void)hint;
-        return insertOrAssignImpl(key, std::forward<Mapped>(obj));
+        return insertOrAssignImpl(key, std::forward<Mapped>(obj)).first;
     }
 
     template <typename Mapped>
-    std::pair<iterator, bool> insert_or_assign(const_iterator hint, key_type&& key, Mapped&& obj) {
+    iterator insert_or_assign(const_iterator hint, key_type&& key, Mapped&& obj) {
         (void)hint;
-        return insertOrAssignImpl(std::move(key), std::forward<Mapped>(obj));
+        return insertOrAssignImpl(std::move(key), std::forward<Mapped>(obj)).first;
     }
 
     std::pair<iterator, bool> insert(const value_type& keyval) {
@@ -1876,18 +1877,18 @@ public:
         return emplace(keyval);
     }
 
-    std::pair<iterator, bool> insert(const_iterator hint, const value_type& keyval) {
+    iterator insert(const_iterator hint, const value_type& keyval) {
         (void)hint;
-        return emplace(keyval);
+        return emplace(keyval).first;
     }
 
     std::pair<iterator, bool> insert(value_type&& keyval) {
         return emplace(std::move(keyval));
     }
 
-    std::pair<iterator, bool> insert(const_iterator hint, value_type&& keyval) {
+    iterator insert(const_iterator hint, value_type&& keyval) {
         (void)hint;
-        return emplace(std::move(keyval));
+        return emplace(std::move(keyval)).first;
     }
 
     // Returns 1 if key is found, 0 otherwise.

--- a/src/test/unit/unit_insert_or_assign.cpp
+++ b/src/test/unit/unit_insert_or_assign.cpp
@@ -40,15 +40,13 @@ TEST_CASE_TEMPLATE("insert_or_assign", Map,
 
     key = "e";
     value = "f";
-    ret = map.insert_or_assign(map.end(), key, value);
-    REQUIRE(ret.second);
-    REQUIRE(ret.first == map.find("e"));
+    auto pos = map.insert_or_assign(map.end(), key, value);
+    REQUIRE(pos == map.find("e"));
     REQUIRE(map.size() == 3);
     REQUIRE(map["e"] == "f");
 
-    ret = map.insert_or_assign(map.begin(), "e", "ff");
-    REQUIRE_FALSE(ret.second);
-    REQUIRE(ret.first == map.find("e"));
+    pos = map.insert_or_assign(map.begin(), "e", "ff");
+    REQUIRE(pos == map.find("e"));
     REQUIRE(map.size() == 3);
     REQUIRE(map["e"] == "ff");
 }

--- a/src/test/unit/unit_try_emplace.cpp
+++ b/src/test/unit/unit_try_emplace.cpp
@@ -54,18 +54,16 @@ TEST_CASE_TEMPLATE("try_emplace", Map, robin_hood::unordered_flat_map<std::strin
     REQUIRE(ret.first->second == RegularType(1U, "b"));
     REQUIRE(map.size() == 2U);
 
-    ret = map.try_emplace(map.end(), "e", 67U, "f");
-    REQUIRE(ret.second);
-    REQUIRE(ret.first == map.find("e"));
-    REQUIRE(ret.first->second == RegularType(67U, "f"));
+    auto pos = map.try_emplace(map.end(), "e", 67U, "f");
+    REQUIRE(pos == map.find("e"));
+    REQUIRE(pos->second == RegularType(67U, "f"));
     REQUIRE(map.size() == 3U);
 
     key = "e";
     RegularType value2(66U, "ff");
-    ret = map.try_emplace(map.begin(), key, value2);
-    REQUIRE_FALSE(ret.second);
-    REQUIRE(ret.first == map.find("e"));
-    REQUIRE(ret.first->second == RegularType(67U, "f"));
+    pos = map.try_emplace(map.begin(), key, value2);
+    REQUIRE(pos == map.find("e"));
+    REQUIRE(pos->second == RegularType(67U, "f"));
     REQUIRE(map.size() == 3U);
 }
 #endif


### PR DESCRIPTION
The return types of the member functions that take a hint to insert an element are different between `robin_hood::unordered_map` and `std::unordered_map`.
As a result, to use `robin_hood::unordered_map`, we need to do more than just replace `std::unordered_map` with `robin_hood::unordered_map`.
I feel that this is preventing users from using `robot_hood::unordered_map`.

# What I would like to do with this pull request
Make the return type of member functions of `robin_hood::unordered_map` that take a hint to insert an element consistent with `std::unordered_map`.

## Specific proposals
The member functions of `robin_hood::detail::Table` that take a hint to insert an element are currently declared as follows.

```cpp
// robin_hood::detail::Table

// emplace_hint
template <typename... Args>
iterator emplace_hint(Args&&... args);

// insert
std::pair<iterator, bool> insert(const_iterator hint, const value_type& keyval);
std::pair<iterator, bool> insert(const_iterator hint, value_type&& keyval);

// try_emplace
template <typename... Args>
std::pair<iterator, bool> try_emplace(const_iterator hint, const key_type& key, Args&&... args);
template <typename... Args>
std::pair<iterator, bool> try_emplace(const_iterator hint, key_type&& key, Args&&... args);

// insert_or_assign
template <typename Mapped>
std::pair<iterator, bool> insert_or_assign(const_iterator hint, const key_type& key, Mapped&& obj);
template <typename Mapped>
std::pair<iterator, bool> insert_or_assign(const_iterator hint, key_type&& key, Mapped&& obj);
```

On the other hand, the corresponding functions of `std::unordered_map` are declared as follows.

*Reference: [Working Draft, Standard for Programming Language C++ - ISO C++ standards committee](http://eel.is/c++draft/unord.map.overview)*

```cpp
// std::unordered_map

// emplace_hint
template<typename... Args>
iterator emplace_hint(const_iterator position, Args&&... args);

// insert
iterator insert(const_iterator hint, const value_type& keyval);
iterator insert(const_iterator hint, value_type&& keyval);

// try_emplace
template<typename... Args>
iterator try_emplace(const_iterator hint, const key_type& key, Args&&... args);
template<typename... Args>
iterator try_emplace(const_iterator hint, key_type&& key, Args&&... args);

// insert_or_assign
template<typename Mapped>
iterator insert_or_assign(const_iterator hint, const key_type& key, Mapped&& obj);
template<typename Mapped>
iterator insert_or_assign(const_iterator hint, key_type&& key, Mapped&& obj);
```

I would like to replace the above declaration with the one below.
Some may argue that making the above change makes it impossible to know whether an element was actually inserted or not.
If this slight difference between `robin_hood::unordered_map` and `std::unordered_map` is *intentional*, please abandon this proposal.

Best regards.
