### PR TITLE
robin_hood.h: Change hash val shifts for `info` and `idx` generation

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -945,7 +945,7 @@ private:
     static constexpr uint32_t InitialInfoNumBits = 5;
     static constexpr uint8_t InitialInfoInc = 1U << InitialInfoNumBits;
     static constexpr size_t InfoMask = InitialInfoInc - 1U;
-    static constexpr uint8_t InitialInfoHashShift = 0;
+    static constexpr uint8_t InitialInfoHashShift = 64 - InitialInfoNumBits;
     using DataPool = detail::NodeAllocator<value_type, 4, 16384, IsFlat>;
 
     // type needs to be wider than uint8_t.
@@ -1355,8 +1355,8 @@ private:
         h ^= h >> 33U;
 
         // the lower InitialInfoNumBits are reserved for info.
-        *info = mInfoInc + static_cast<InfoType>((h & InfoMask) >> mInfoHashShift);
-        *idx = (static_cast<size_t>(h) >> InitialInfoNumBits) & mMask;
+        *info = mInfoInc + static_cast<InfoType>(h >> mInfoHashShift);
+        *idx = static_cast<size_t>(h) & mMask;
     }
 
     // forwards the index by one, wrapping around at the end


### PR DESCRIPTION
Instead of generating the `info` hash bits with a mask + shift, we can
just use an unsigned shift from the end as that will bring in zeros.

With that change the `idx` hash bits can start from the begining so we
no longer need to shift out the `info` hash bits.

Saves 2x instructions. Only ALU but this function is in the critical
path.

There does not appear to be any issue with false hits changing the tag
bits used.

False Tag Match Rates:

                      :   New,   Cur

Insert Seq Ints:
2^10                  : 2.539, 2.832
2^12                  : 3.076, 3.003
2^14                  : 2.960, 3.497
2^16                  : 4.048, 4.306
2^18                  : 4.543, 4.732
2^20                  : 5.182, 5.553
2^22                  : 5.579, 5.557
2^24                  : 6.237, 6.017
2^26                  : 6.599, 6.432

Insert Rand Ints (seed = 0):
2^10                  : 2.637, 4.199
2^12                  : 2.979, 3.613
2^14                  : 3.662, 3.955
2^16                  : 4.309, 4.849
2^18                  : 4.626, 4.564
2^20                  : 4.849, 5.044
2^22                  : 6.050, 5.279
2^24                  : 5.664, 6.350
2^26                  : 6.640, 6.771

Insert Strings:
All Words(0)          : 4.974, 5.231
10k Words(1)          : 3.550, 4.000
URLS(2)               : 5.548, 5.683
URLS(2) w/ "http://"  : 5.466, 5.831
URLS(2) w/ "https://" : 5.569, 5.761

[0]: https://github.com/dwyl/english-words
[1]: https://github.com/first20hours/google-10000-english
[2]: https://www.domcop.com/top-10-million-websites