### PR TITLE
Don't discart try_increase_info return on increase_size.

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -2433,8 +2433,8 @@ private:
         }
 
         auto const maxNumElementsAllowed = calcMaxNumElementsAllowed(mMask + 1);
-        if (mNumElements < maxNumElementsAllowed && try_increase_info()) {
-            return true;
+        if (mNumElements < maxNumElementsAllowed) {
+            return try_increase_info();
         }
 
         ROBIN_HOOD_LOG("mNumElements=" << mNumElements << ", maxNumElementsAllowed="


### PR DESCRIPTION
This is due to increase_size always returning true if we discart its return, making the lines that checks for failure on increase_size inside insertKeyPrepareEmptySpot to never be reached.