### PR TITLE
Enable std::is_trivially_copyable in clang

### DIFF
--- a/src/include/robin_hood.h
+++ b/src/include/robin_hood.h
@@ -206,7 +206,7 @@ static Counts& counts() {
 
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 // See https://stackoverflow.com/a/31798726/48181
-#if defined(__GNUC__) && __GNUC__ < 5
+#if defined(__GNUC__) && __GNUC__ < 5 && !defined(__clang__)
 #    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
 #else
 #    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value


### PR DESCRIPTION
Clang has this weird behavior of setting `__GNUC__` to 4, hence clang will always take the if branch. This is suboptimal because `std::is_trivially_copyable` has almost always been in clang. This patch should fix it.

Note that starting with clang 15 a warning is raised for the current implementation:
`warning: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Wdeprecated-builtins]`